### PR TITLE
[20] Add a new calibration layer

### DIFF
--- a/bundles/fr.adaussy.permadeler.model.design/description/permadeler.odesign
+++ b/bundles/fr.adaussy.permadeler.model.design/description/permadeler.odesign
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <description:Group xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:properties="http://www.eclipse.org/sirius/properties/1.0.0" xmlns:properties-ext-widgets-reference="http://www.eclipse.org/sirius/properties/1.0.0/ext/widgets/reference" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:tool="http://www.eclipse.org/sirius/diagram/description/tool/1.1.0" xmlns:tool_1="http://www.eclipse.org/sirius/description/tool/1.1.0" name="model" version="12.0.0.2017041100">
   <ownedViewpoints name="FoodForestViewPoint" modelFileExtension="*.Permadeler">
-    <ownedRepresentations xsi:type="description_1:DiagramDescription" dropDescriptions="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@toolSections.1/@ownedTools[name='PMD_CreatePlantationFromType']" name="FoodForestMapDiagram" label="Carte Implantation Foret Jardin" titleExpression="aql:'Carte Implantation'" initialisation="true" showOnStartup="true" domainClass="Permadeler::PlantationPhase" enablePopupBars="true" imagePath="/fr.adaussy.permadeler.model.design/img/plan.png">
+    <ownedRepresentations xsi:type="description_1:DiagramDescription" dropDescriptions="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@toolSections.1/@ownedTools[name='PMD_CreatePlantationFromType'] //@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@toolSections.1/@ownedTools[name='PMD_DropPlantation']" name="FoodForestMapDiagram" label="Carte Implantation Foret Jardin" titleExpression="aql:'Carte Implantation'" initialisation="true" showOnStartup="true" domainClass="Permadeler::PlantationPhase" enablePopupBars="true" imagePath="/fr.adaussy.permadeler.model.design/img/plan.png">
+      <metamodel href="http://www.example.org/fr.adaussy.permadeler.model#/"/>
       <filters xsi:type="filter:CompositeFilterDescription" name="PMD_TopLayer" label="Cacher les strates hausse (Canopée, Sous Canopée)">
         <filters xsi:type="filter:MappingFilter" mappings="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@nodeMappings[name='PMD_Plantation']" semanticConditionExpression="aql:self.currentLayer != Permadeler::Layer::CANOPY and self.currentLayer != Permadeler::Layer::UNDERSTORY"/>
       </filters>
@@ -12,31 +13,27 @@
         <filters xsi:type="filter:MappingFilter" mappings="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@nodeMappings[name='PMD_Plantation']" semanticConditionExpression="aql:self.currentLayer != Permadeler::Layer::GROUND_COVER and self.currentLayer != Permadeler::Layer::ROOT and self.currentLayer != Permadeler::Layer::HERB"/>
       </filters>
       <defaultLayer name="Default">
-        <nodeMappings name="PMD_Plantation" label="Plantation" semanticCandidatesExpression="aql:self.plantations" doubleClickDescription="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@toolSections.3/@ownedTools[name='PlantationDoubleClicTool']" domainClass="Permadeler::Plantation" dropDescriptions="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@toolSections.1/@ownedTools[name='PMD_CreatePlantationFromType']">
-          <style xsi:type="style:WorkspaceImageDescription" labelSize="12" showIcon="false" labelExpression="aql:self.getPlantationLabel()" tooltipExpression="aql:self.getLabelProviderText()" sizeComputationExpression="aql:self.getSVGSize()" labelPosition="node" resizeKind="NSEW" workspacePath="/fr.adaussy.permadeler.model.design/img/understory.svg">
+        <nodeMappings name="PMD_Plantation" label="Plantation" semanticCandidatesExpression="aql:self.plantations" createElements="false" doubleClickDescription="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@toolSections.3/@ownedTools[name='PlantationDoubleClicTool']" domainClass="Permadeler::Plantation" dropDescriptions="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@toolSections.1/@ownedTools[name='PMD_CreatePlantationFromType']">
+          <style xsi:type="style:WorkspaceImageDescription" labelSize="12" showIcon="false" labelExpression="aql:self.getPlantationLabel()" tooltipExpression="aql:self.getLabelProviderText()" sizeComputationExpression="" labelPosition="node" resizeKind="NSEW" workspacePath="/fr.adaussy.permadeler.model.design/img/understory.svg">
             <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
             <labelFormat>bold</labelFormat>
             <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_red']"/>
           </style>
           <conditionnalStyles predicateExpression="aql:self.wireframe">
-            <style xsi:type="style:WorkspaceImageDescription" labelSize="12" showIcon="false" labelExpression="aql:self.getPlantationLabel()" labelColor="//@userColorsPalettes[name='DiagramColors']/@entries[name='LabelLightGray']" tooltipExpression="aql:self.type.name" sizeComputationExpression="aql:self.getSVGSize()" labelPosition="node" resizeKind="NSEW" workspacePath="/fr.adaussy.permadeler.model.design/img/understory.svg">
+            <style xsi:type="style:WorkspaceImageDescription" labelSize="12" showIcon="false" labelExpression="aql:self.getPlantationLabel()" labelColor="//@userColorsPalettes[name='DiagramColors']/@entries[name='LabelLightGray']" tooltipExpression="aql:self.type.name" sizeComputationExpression="" labelPosition="node" resizeKind="NSEW" workspacePath="/fr.adaussy.permadeler.model.design/img/understory.svg">
               <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
               <labelFormat>bold</labelFormat>
             </style>
           </conditionnalStyles>
-        </nodeMappings>
-        <nodeMappings name="CI_DiagSizeMarker" semanticCandidatesExpression="aql:self" synchronizationLock="true" domainClass="Permadeler::PlantationPhase">
-          <style xsi:type="style:WorkspaceImageDescription" labelSize="1" showIcon="false" labelExpression="" tooltipExpression="Marqueur de fin de plan" hideLabelByDefault="true" sizeComputationExpression="-1" resizeKind="NSEW" workspacePath="/fr.adaussy.permadeler.model.design/img/EndDiagMarker.svg">
-            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
-            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
-          </style>
         </nodeMappings>
         <toolSections name="CreationSection_Plantations" label="Create">
           <ownedTools xsi:type="tool:NodeCreationDescription" name="PMD_PlantationCreationTool" label="Planter plante Connue" nodeMappings="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@nodeMappings[name='PMD_Plantation']" iconPath="/fr.adaussy.permadeler.model.edit/icons/other/icons/019-trowel.png">
             <variable name="container"/>
             <viewVariable name="containerView"/>
             <initialOperation>
-              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="aql:self.createPlantation()"/>
+              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="aql:self.createPlantation()">
+                <subModelOperations xsi:type="tool:CreateView" mapping="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@nodeMappings[name='PMD_Plantation']" containerViewExpression="var:containerView"/>
+              </firstModelOperations>
             </initialOperation>
           </ownedTools>
           <ownedTools xsi:type="tool:NodeCreationDescription" name="PMD_PlantationCreationToolNewPlant" label="Planter nouvelle espece" nodeMappings="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@nodeMappings[name='PMD_Plantation']" iconPath="/fr.adaussy.permadeler.model.edit/icons/custo/commons/species.png">
@@ -53,7 +50,9 @@
                   </buttons>
                   <page name="NewSpeciesDialog_Page" labelExpression="Plante" domainClass="Permadeler::Plant" semanticCandidateExpression="var:self" groups="//@extensions.0/@categories.0/@groups.2 //@extensions.0/@categories.0/@groups.1 //@extensions.0/@categories.0/@groups.3 //@extensions.0/@categories.0/@groups.8 //@extensions.0/@categories.0/@groups.14 //@extensions.0/@categories.0/@groups.13 //@extensions.0/@categories.0/@groups.7 //@extensions.0/@categories.0/@groups.20 //@extensions.0/@categories.0/@groups.9 //@extensions.0/@categories.0/@groups.10 //@extensions.0/@categories.0/@groups.0"/>
                 </subModelOperations>
-                <subModelOperations xsi:type="tool_1:ChangeContext" browseExpression="aql:container.createPlantation(self,true)"/>
+                <subModelOperations xsi:type="tool_1:ChangeContext" browseExpression="aql:container.createPlantation(self,true)">
+                  <subModelOperations xsi:type="tool:CreateView" mapping="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@nodeMappings[name='PMD_Plantation']" containerViewExpression="var:containerView"/>
+                </subModelOperations>
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
@@ -72,7 +71,9 @@
                   <page name="Default Page" labelExpression="Plante" domainClass="Permadeler::Plant" semanticCandidateExpression="var:self" groups="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@toolSections.0/@ownedTools[name='PMD_PlantationCreationToolNewVariety']/@initialOperation/@firstModelOperations/@subModelOperations.0/@groups.0 //@extensions.0/@categories.0/@groups.3 //@extensions.0/@categories.0/@groups.14 //@extensions.0/@categories.0/@groups.13 //@extensions.0/@categories.0/@groups.0"/>
                   <groups name="LatinNameGroup_NewPlant" labelExpression="aql:'Latin Name'" domainClass="Permadeler::Plant" semanticCandidateExpression="var:self" extends="//@extensions.0/@categories.0/@groups.2"/>
                 </subModelOperations>
-                <subModelOperations xsi:type="tool_1:ChangeContext" browseExpression="aql:container.createPlantation(self,true)"/>
+                <subModelOperations xsi:type="tool_1:ChangeContext" browseExpression="aql:container.createPlantation(self,true)">
+                  <subModelOperations xsi:type="tool:CreateView" mapping="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@nodeMappings[name='PMD_Plantation']" containerViewExpression="var:containerView"/>
+                </subModelOperations>
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
@@ -85,14 +86,27 @@
           </ownedTools>
         </toolSections>
         <toolSections name="DndToolPlantationsPlantations">
-          <ownedTools xsi:type="tool:ContainerDropDescription" name="PMD_CreatePlantationFromType" dragSource="PROJECT_EXPLORER">
+          <ownedTools xsi:type="tool:ContainerDropDescription" name="PMD_CreatePlantationFromType" precondition="aql:element.oclIsKindOf(Permadeler::Plant)" dragSource="PROJECT_EXPLORER">
             <oldContainer name="oldSemanticContainer"/>
             <newContainer name="newSemanticContainer"/>
             <element name="element"/>
             <newViewContainer name="newContainerView"/>
             <initialOperation>
               <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="aql:self">
-                <subModelOperations xsi:type="tool_1:ChangeContext" browseExpression="aql:newSemanticContainer.createPlantation(element,false)"/>
+                <subModelOperations xsi:type="tool_1:ChangeContext" browseExpression="aql:newSemanticContainer.createPlantation(element,false)">
+                  <subModelOperations xsi:type="tool:CreateView" mapping="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@nodeMappings[name='PMD_Plantation']" containerViewExpression="var:newContainerView"/>
+                </subModelOperations>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:ContainerDropDescription" name="PMD_DropPlantation" precondition="aql:element.oclIsKindOf(Permadeler::Plantation)" dragSource="PROJECT_EXPLORER">
+            <oldContainer name="oldSemanticContainer"/>
+            <newContainer name="newSemanticContainer"/>
+            <element name="element"/>
+            <newViewContainer name="newContainerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="aql:element">
+                <subModelOperations xsi:type="tool:CreateView" mapping="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@defaultLayer/@nodeMappings[name='PMD_Plantation']" containerViewExpression="var:newContainerView"/>
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
@@ -144,6 +158,86 @@
           </vsmElementCustomizations>
         </customization>
       </defaultLayer>
+      <additionalLayers name="CalibrationLayer" activeByDefault="true">
+        <nodeMappings name="CI_DiagSizeMarker" semanticCandidatesExpression="aql:self" synchronizationLock="true" domainClass="Permadeler::PlantationPhase">
+          <style xsi:type="style:WorkspaceImageDescription" labelSize="1" showIcon="false" labelExpression="" tooltipExpression="Marqueur de fin de plan" hideLabelByDefault="true" sizeComputationExpression="-1" resizeKind="NSEW" workspacePath="/fr.adaussy.permadeler.model.design/img/EndDiagMarker.svg">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+          </style>
+        </nodeMappings>
+        <nodeMappings name="PMD_CANOPY_Calibration" deletionDescription="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@additionalLayers[name='CalibrationLayer']/@toolSections.0/@ownedTools[name='NotAllowedDelete']" semanticCandidatesExpression="aql:self" synchronizationLock="true" domainClass="Permadeler::PlantationPhase">
+          <style xsi:type="style:DotDescription" labelSize="12" showIcon="false" labelExpression="aql:'Canope'" sizeComputationExpression="aql:Permadeler::Layer::CANOPY.getSVGSize()" resizeKind="NSEW" strokeSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelFormat>bold</labelFormat>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </nodeMappings>
+        <nodeMappings name="PMD_UNDERSTORY_Calibration" deletionDescription="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@additionalLayers[name='CalibrationLayer']/@toolSections.0/@ownedTools[name='NotAllowedDelete']" semanticCandidatesExpression="aql:self" synchronizationLock="true" domainClass="Permadeler::PlantationPhase">
+          <style xsi:type="style:DotDescription" labelSize="12" showIcon="false" labelExpression="aql:'Sous Canopee'" sizeComputationExpression="aql:Permadeler::Layer::UNDERSTORY.getSVGSize()" resizeKind="NSEW" strokeSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelFormat>bold</labelFormat>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </nodeMappings>
+        <nodeMappings name="PMD_SHRUB_Calibration" deletionDescription="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@additionalLayers[name='CalibrationLayer']/@toolSections.0/@ownedTools[name='NotAllowedDelete']" semanticCandidatesExpression="aql:self" synchronizationLock="true" domainClass="Permadeler::PlantationPhase">
+          <style xsi:type="style:DotDescription" labelSize="12" showIcon="false" labelExpression="aql:'Arbuste'" sizeComputationExpression="aql:Permadeler::Layer::SHRUB.getSVGSize()" resizeKind="NSEW" strokeSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelFormat>bold</labelFormat>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </nodeMappings>
+        <nodeMappings name="PMD_HERB_Calibration" deletionDescription="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@additionalLayers[name='CalibrationLayer']/@toolSections.0/@ownedTools[name='NotAllowedDelete']" semanticCandidatesExpression="aql:self" synchronizationLock="true" domainClass="Permadeler::PlantationPhase">
+          <style xsi:type="style:DotDescription" labelSize="12" showIcon="false" labelExpression="aql:'Herbacé'" sizeComputationExpression="aql:Permadeler::Layer::HERB.getSVGSize()" resizeKind="NSEW" strokeSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelFormat>bold</labelFormat>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </nodeMappings>
+        <nodeMappings name="PMD_ROOT_Calibration" deletionDescription="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@additionalLayers[name='CalibrationLayer']/@toolSections.0/@ownedTools[name='NotAllowedDelete']" semanticCandidatesExpression="aql:self" synchronizationLock="true" domainClass="Permadeler::PlantationPhase">
+          <style xsi:type="style:DotDescription" labelSize="12" showIcon="false" labelExpression="aql:'Racines'" sizeComputationExpression="aql:Permadeler::Layer::ROOT.getSVGSize()" resizeKind="NSEW" strokeSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelFormat>bold</labelFormat>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </nodeMappings>
+        <nodeMappings name="PMD_GROUND_COVER_Calibration" deletionDescription="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@additionalLayers[name='CalibrationLayer']/@toolSections.0/@ownedTools[name='NotAllowedDelete']" semanticCandidatesExpression="aql:self" synchronizationLock="true" domainClass="Permadeler::PlantationPhase">
+          <style xsi:type="style:DotDescription" labelSize="12" showIcon="false" labelExpression="aql:'Couvert Vegetal'" sizeComputationExpression="aql:Permadeler::Layer::GROUND_COVER.getSVGSize()" resizeKind="NSEW" strokeSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelFormat>bold</labelFormat>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </nodeMappings>
+        <nodeMappings name="PMD_VINE_Calibration" deletionDescription="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@additionalLayers[name='CalibrationLayer']/@toolSections.0/@ownedTools[name='NotAllowedDelete']" semanticCandidatesExpression="aql:self" synchronizationLock="true" domainClass="Permadeler::PlantationPhase">
+          <style xsi:type="style:DotDescription" labelSize="12" showIcon="false" labelExpression="aql:'Liane'" sizeComputationExpression="aql:Permadeler::Layer::VINE.getSVGSize()" resizeKind="NSEW" strokeSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelFormat>bold</labelFormat>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </nodeMappings>
+        <nodeMappings name="PMD_OTHER_Calibration" deletionDescription="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='FoodForestMapDiagram']/@additionalLayers[name='CalibrationLayer']/@toolSections.0/@ownedTools[name='NotAllowedDelete']" semanticCandidatesExpression="aql:self" synchronizationLock="true" domainClass="Permadeler::PlantationPhase">
+          <style xsi:type="style:DotDescription" labelSize="12" showIcon="false" labelExpression="aql:'Autre'" sizeComputationExpression="aql:Permadeler::Layer::OTHER.getSVGSize()" resizeKind="NSEW" strokeSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelFormat>bold</labelFormat>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </nodeMappings>
+        <toolSections name="CIFL_Cal_Tools">
+          <ownedTools xsi:type="tool:DeleteElementDescription" name="NotAllowedDelete">
+            <element name="element"/>
+            <elementView name="elementView"/>
+            <containerView name="containerView"/>
+            <initialOperation/>
+          </ownedTools>
+        </toolSections>
+      </additionalLayers>
     </ownedRepresentations>
     <ownedRepresentations xsi:type="description_1:DiagramDescription" dropDescriptions="//@ownedViewpoints[name='FoodForestViewPoint']/@ownedRepresentations[name='NursaryDiag']/@defaultLayer/@toolSections.0/@ownedTools[name='MoveTray']" name="NursaryDiag" domainClass="Permadeler::Nursary" enablePopupBars="true">
       <metamodel href="../../fr.adaussy.permadeler.model/model/Permadeler.ecore#/"/>

--- a/bundles/fr.adaussy.permadeler.model.design/plugin.xml
+++ b/bundles/fr.adaussy.permadeler.model.design/plugin.xml
@@ -16,4 +16,10 @@
         </Priority>
      </editpartProvider>
   </extension>
+  <extension
+        point="org.eclipse.sirius.sessionManagerListener">
+     <listener
+           class="fr.adaussy.permadeler.model.design.session.DesignSessionManagerListener">
+     </listener>
+  </extension>
 </plugin>

--- a/bundles/fr.adaussy.permadeler.model.design/src/fr/adaussy/permadeler/model/design/services/DiagramService.java
+++ b/bundles/fr.adaussy.permadeler.model.design/src/fr/adaussy/permadeler/model/design/services/DiagramService.java
@@ -427,14 +427,14 @@ public class DiagramService {
 	}
 
 	/**
-	 * Gets SVG size of a plantation. The size depends of the nature of the plantation
+	 * Gets the default SVG size of an image representing a given layer
 	 * 
-	 * @param plantation
+	 * @param phase
 	 *            a plantation
 	 * @return a size
 	 */
-	public static int getSVGSize(final Plantation plantation) {
-		return switch (plantation.getCurrentLayer()) {
+	public static int getSVGSize(Layer currentLayer) {
+		return switch (currentLayer) {
 			case CANOPY -> 9;
 			case UNDERSTORY -> 7;
 			case SHRUB -> 5;

--- a/bundles/fr.adaussy.permadeler.model.design/src/fr/adaussy/permadeler/model/design/session/DesignSessionManagerListener.java
+++ b/bundles/fr.adaussy.permadeler.model.design/src/fr/adaussy/permadeler/model/design/session/DesignSessionManagerListener.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Arthur Daussy.
+ *
+ * This program and the accompanying materials are made 
+ * available under the terms of the Eclipse Public License 2.0 
+ * which is available at https://www.eclipse.org/legal/epl-2.0/ 
+ * Contributors:
+ * Arthur Daussy - initial API and implementation.
+ ******************************************************************************/
+package fr.adaussy.permadeler.model.design.session;
+
+import org.eclipse.emf.transaction.NotificationFilter;
+import org.eclipse.gmf.runtime.notation.Diagram;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.business.api.session.SessionManagerListener;
+import org.eclipse.sirius.viewpoint.description.Viewpoint;
+
+import fr.adaussy.permadeler.model.design.utils.SizeAndBoundFixerChangeTrigger;
+
+public class DesignSessionManagerListener implements SessionManagerListener {
+
+	public DesignSessionManagerListener() {
+	}
+
+	@Override
+	public void notify(Session session, int arg1) {
+	}
+
+	@Override
+	public void notifyAddSession(Session newSession) {
+		newSession.getEventBroker().addLocalTrigger(
+				NotificationFilter.createNotifierTypeFilter(Diagram.class),
+				new SizeAndBoundFixerChangeTrigger(newSession.getTransactionalEditingDomain()));
+
+	}
+
+	@Override
+	public void notifyRemoveSession(Session session) {
+	}
+
+	@Override
+	public void viewpointDeselected(Viewpoint viewpoint) {
+	}
+
+	@Override
+	public void viewpointSelected(Viewpoint viewpoint) {
+	}
+
+}

--- a/bundles/fr.adaussy.permadeler.model.design/src/fr/adaussy/permadeler/model/design/utils/SizeAndBoundFixerChangeTrigger.java
+++ b/bundles/fr.adaussy.permadeler.model.design/src/fr/adaussy/permadeler/model/design/utils/SizeAndBoundFixerChangeTrigger.java
@@ -80,6 +80,8 @@ public class SizeAndBoundFixerChangeTrigger implements ModelChangeTrigger {
 			protected void doExecute() {
 				bounds.setHeight(calibrationBounds.getHeight());
 				bounds.setWidth(calibrationBounds.getWidth());
+				bounds.setX(bounds.getX() - calibrationBounds.getWidth() / 2);
+				bounds.setY(bounds.getY() - calibrationBounds.getHeight() / 2);
 
 			}
 		};

--- a/bundles/fr.adaussy.permadeler.model.design/src/fr/adaussy/permadeler/model/design/utils/SizeAndBoundFixerChangeTrigger.java
+++ b/bundles/fr.adaussy.permadeler.model.design/src/fr/adaussy/permadeler/model/design/utils/SizeAndBoundFixerChangeTrigger.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Arthur Daussy.
+ *
+ * This program and the accompanying materials are made 
+ * available under the terms of the Eclipse Public License 2.0 
+ * which is available at https://www.eclipse.org/legal/epl-2.0/ 
+ * Contributors:
+ * Arthur Daussy - initial API and implementation.
+ ******************************************************************************/
+package fr.adaussy.permadeler.model.design.utils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.CompoundCommand;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.transaction.RecordingCommand;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.gmf.runtime.notation.Bounds;
+import org.eclipse.gmf.runtime.notation.Diagram;
+import org.eclipse.gmf.runtime.notation.Node;
+import org.eclipse.sirius.business.api.session.ModelChangeTrigger;
+import org.eclipse.sirius.diagram.DNode;
+import org.eclipse.sirius.ext.base.Option;
+import org.eclipse.sirius.ext.base.Options;
+
+import fr.adaussy.permadeler.model.Permadeler.Layer;
+import fr.adaussy.permadeler.model.Permadeler.Plantation;
+
+/**
+ * Model change trigger that is in charge of setting property the size and the coordinate of a new plantation
+ * in a representation.
+ * 
+ * @author Arthur Daussy
+ */
+public class SizeAndBoundFixerChangeTrigger implements ModelChangeTrigger {
+
+	private static final String NODE_TYPE = "2001";
+
+	private static final String PMD_PLANTATION_MAPING_NAME = "PMD_Plantation";
+
+	private TransactionalEditingDomain transactionalEditingDomain;
+
+	public SizeAndBoundFixerChangeTrigger(TransactionalEditingDomain transactionalEditingDomain) {
+		this.transactionalEditingDomain = transactionalEditingDomain;
+	}
+
+	@Override
+	public int priority() {
+		return 0;
+	}
+
+	private Optional<Command> matchAddPlantationNodeNotification(Notification notification) {
+		if (notification.getEventType() == Notification.ADD
+				&& notification.getNotifier() instanceof Diagram diagram //
+				&& notification.getNewValue() instanceof Node node //
+				&& NODE_TYPE.equals(node.getType())//
+				&& node.getElement() instanceof DNode dNode //
+				&& dNode.getActualMapping() != null//
+				&& PMD_PLANTATION_MAPING_NAME.equals(dNode.getActualMapping().getName())//
+				&& node.getLayoutConstraint() instanceof Bounds bounds//
+				&& dNode.getTarget() instanceof Plantation plantation) {
+
+			Layer layer = plantation.getCurrentLayer();
+
+			return getCalibrationBounds(diagram, layer)
+					.map(calibrationBounds -> createChangeBoundCommand(calibrationBounds, bounds));
+
+		}
+		return Optional.empty();
+	}
+
+	private Command createChangeBoundCommand(Bounds calibrationBounds, Bounds bounds) {
+
+		RecordingCommand cmd = new RecordingCommand(transactionalEditingDomain) {
+
+			@Override
+			protected void doExecute() {
+				bounds.setHeight(calibrationBounds.getHeight());
+				bounds.setWidth(calibrationBounds.getWidth());
+
+			}
+		};
+		return cmd;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Optional<Bounds> getCalibrationBounds(Diagram diagram, Layer layer) {
+		return diagram.getChildren().stream()
+				.filter(child -> child instanceof Node node && node.getLayoutConstraint() instanceof Bounds
+						&& isCalibrationNodeForLayer(node, layer))
+				.map(child -> (Bounds)((Node)child).getLayoutConstraint()).findFirst();
+	}
+
+	private boolean isCalibrationNodeForLayer(Node node, Layer layer) {
+		return node.getElement() instanceof DNode dNode && dNode.getActualMapping() != null
+				&& buildCalibrationMappingName(layer).equals(dNode.getActualMapping().getName());
+	}
+
+	private String buildCalibrationMappingName(Layer layer) {
+		return "PMD_" + layer.getName() + "_Calibration";
+	}
+
+	@Override
+	public Option<Command> localChangesAboutToCommit(Collection<Notification> notifications) {
+
+		List<Command> commands = notifications.stream().map(this::matchAddPlantationNodeNotification)
+				.filter(Optional::isPresent).map(Optional::get).toList();
+
+		if (commands.isEmpty()) {
+			return Options.newNone();
+		} else if (commands.size() == 1) {
+			return Options.newSome(commands.get(0));
+		} else {
+			CompoundCommand cc = new CompoundCommand(0, commands);
+			return Options.newSome(cc);
+		}
+	}
+}

--- a/doc/user/pages/ReleaseNote.adoc
+++ b/doc/user/pages/ReleaseNote.adoc
@@ -1,5 +1,11 @@
 = Release Note
 
+== 0.5.0
+
+* https://github.com/adaussy/permadeler/issues/20[Ajouter des calibres pour chaque strate]
+
+
+
 == 0.4.0
 
 * Première version de l'importation des plantes depuis la base de donnée des Alvéoles (https://plantes.universite-alveoles.fr/plant/index). Travail encore en cours


### PR DESCRIPTION
This layer add 7 news nodes that can be used to calibrate the creation of the future plantations depending of their layer.

Note that from now own the plantation displayed are desynchronized from the model. You need to use a tool palette or a Drag and Drop to display them.

Bug: https://github.com/adaussy/permadeler/issues/20